### PR TITLE
Syntax simplification (most parentheses and semicolons are removed)

### DIFF
--- a/compiler/CodeLine.h.rush
+++ b/compiler/CodeLine.h.rush
@@ -2,13 +2,13 @@
 
 struct CodeLine
     public:
-    CodeLine(const std::string origin, const int number, const std::string code, const int indentation);
+    CodeLine(const std::string origin, const int number, const std::string code, const int indentation)
 
     // Source file
-    const std::string origin;
+    const std::string origin
     // Line number in source file
-    const int number;
+    const int number
     // Code on the line (without leading and trailing whitespace)
-    const std::string code;
+    const std::string code
     // Number of leading whitespace characters
-    const int indentation;
+    const int indentation

--- a/compiler/Compiler.h.rush
+++ b/compiler/Compiler.h.rush
@@ -6,17 +6,17 @@
 
 class Compiler
     public:
-    Compiler(const std::string mainSourcePath);
-    std::string compile(const bool originMode) const;
+    Compiler(const std::string mainSourcePath)
+    std::string compile(const bool originMode) const
 
     private:
-    std::vector<std::string> m_loadedFiles;
-    std::vector<std::string> m_includes;
-    std::vector<CodeLine> m_lines;
-    std::map<std::string, Literal> m_literals;
+    std::vector<std::string> m_loadedFiles
+    std::vector<std::string> m_includes
+    std::vector<CodeLine> m_lines
+    std::map<std::string, Literal> m_literals
 
-    void loadFile(const std::string path);
-    std::string addLiteral(const Literal value);
-    void includeHeader(const std::string header, const bool warnIfAlreadyIncluded);
-    std::string getCleanCode(const std::string line);
-    void processLine(const std::string line, const std::string origin, const int number);
+    void loadFile(const std::string path)
+    std::string addLiteral(const Literal value)
+    void includeHeader(const std::string header, const bool warnIfAlreadyIncluded)
+    std::string getCleanCode(const std::string line)
+    void processLine(const std::string line, const std::string origin, const int number)

--- a/compiler/Compiler.rush
+++ b/compiler/Compiler.rush
@@ -83,15 +83,15 @@ std::string Compiler::addLiteral(const Literal value)
     std::string strType;
 
     switch value.type()
-        case LiteralType::String:
+        case LiteralType::String
         strType = "STRING";
         break;
 
-        case LiteralType::Number:
+        case LiteralType::Number
         strType = "NUMBER";
         break;
 
-        default:
+        default
         strType = "UNKNOWN";
         break;
 
@@ -135,7 +135,10 @@ std::string Compiler::compile(const bool originMode) const
             typeDefLevels.push_back(indentationLevels.size() + 1);
 
         // Add parentheses to conditions and loops
-        regexReplaceInPlace(line, `^((?:else\s+)?if|for|while|switch)\s+(.+?)(\\s*{\s*\})?$`, "$1($2)$3");
+        regexReplaceInPlace(line, `^((?:else\s+)?if|for|while|switch)\s+(.+?)(\s*\{\s*\})?$`, "$1($2)$3");
+
+        // Add colons after switch cases
+        regexReplaceInPlace(line, "^(case .*|default)$", "$1:");
 
         // Put literal values back
         for std::pair<std::string, Literal> lit : m_literals

--- a/compiler/Compiler.rush
+++ b/compiler/Compiler.rush
@@ -7,244 +7,249 @@
 #include "CodeLine.h.rush"
 #include "Literal.h.rush"
 
-using namespace support;
+using namespace support
 
 Compiler::Compiler(const std::string mainSourcePath)
-    loadFile(mainSourcePath);
+    loadFile(mainSourcePath)
 
 std::string getOriginStr(const CodeLine line)
-    return "// " + line.origin + " : " + std::to_string(line.number) + '\n';
+    return "// " + line.origin + " : " + std::to_string(line.number) + '\n'
 
 void Compiler::loadFile(const std::string path)
     if contains(m_loadedFiles, path)
-        printLnWarn("File already loaded: " + path);
-        return;
+        printLnWarn("File already loaded: " + path)
+        return
 
-    printLn(`Reading file: "` + path + `"`);
+    printLn(`Reading file: "` + path + `"`)
 
-    m_loadedFiles.push_back(path);
-    std::ifstream file(path);
+    m_loadedFiles.push_back(path)
+    std::ifstream file(path)
 
     if !file
-        throw std::runtime_error("Unable to open file for reading");
+        throw std::runtime_error("Unable to open file for reading")
 
     // Read source file lines
-    std::string multiLine;
-    int multiLineStart;
+    std::string multiLine
+    int multiLineStart
 
-    int lineCounter = 1;
+    int lineCounter = 1
     for std::string line; getline(file, line); lineCounter++
         // Check if the line ends with a backslash
         // Backslash means that the next line is supposed to be appended to this one
         // If there is a comment at the end of the line, remove it
-        RegexMatch match = regexMatch(line, `(.*)\\\s*(?://.*)?`);
+        RegexMatch match = regexMatch(line, `(.*)\\\s*(?://.*)?`)
 
         // Multi-line
         if match.success()
-            std::string beforeBackslash = match[0];
+            std::string beforeBackslash = match[0]
 
             // Subsequent lines
             if multiLineStart
-                multiLine += beforeBackslash.substr(getIndentation(beforeBackslash));
+                multiLine += beforeBackslash.substr(getIndentation(beforeBackslash))
             // The first line of the multi-line
             else
-                multiLine = beforeBackslash;
-                multiLineStart = lineCounter;
+                multiLine = beforeBackslash
+                multiLineStart = lineCounter
         // Regular single line, but the previous lines were a multi-line
         else if multiLineStart
-            multiLine += line.substr(getIndentation(line));
-            processLine(multiLine, path, multiLineStart);
+            multiLine += line.substr(getIndentation(line))
+            processLine(multiLine, path, multiLineStart)
 
-            multiLineStart = 0;
-            multiLine.clear();
+            multiLineStart = 0
+            multiLine.clear()
         // Regular singtle line and so was the previous line
         else
-            processLine(line, path, lineCounter);
+            processLine(line, path, lineCounter)
 
     // Trailing multi-line at the end of a file
     // This should not really happen, but just to be safe
     if multiLineStart
-        processLine(multiLine, path, multiLineStart);
+        processLine(multiLine, path, multiLineStart)
 
-    printLn(`File loaded: "` + path + `"`);
+    printLn(`File loaded: "` + path + `"`)
 
 void _endScope(std::string &code, std::vector<int> &indentationLevels, std::vector<int> &typeDefLevels)
     // End of type definition
     if indentationLevels.size() == typeDefLevels.back()
-        code += "};\n";
-        typeDefLevels.pop_back();
+        code += "};\n"
+        typeDefLevels.pop_back()
     // End of a different code block
     else
-        code += "}\n";
+        code += "}\n"
 
-    indentationLevels.pop_back();
+    indentationLevels.pop_back()
 
 std::string Compiler::addLiteral(const Literal value)
-    std::string strType;
+    std::string strType
 
     switch value.type()
         case LiteralType::String
-        strType = "STRING";
-        break;
+        strType = "STRING"
+        break
 
         case LiteralType::Number
-        strType = "NUMBER";
-        break;
+        strType = "NUMBER"
+        break
 
         default
-        strType = "UNKNOWN";
-        break;
+        strType = "UNKNOWN"
+        break
 
     // Generate a placeholder name for the literal value
-    std::string name = "__LITERAL__" + strType + "__" + std::to_string(m_literals.size()) + "__";
+    std::string name = "__LITERAL__" + strType + "__" + std::to_string(m_literals.size()) + "__"
 
     // Add the literal to the map
-    m_literals[name] = value;
+    m_literals[name] = value
 
-    return name;
+    return name
 
 std::string Compiler::compile(const bool originMode) const
-    std::string code;
+    std::string code
 
     // Include headers
     for std::string include : m_includes
-        code += "#include <" + include + ">\n";
+        code += "#include <" + include + ">\n"
 
-    std::vector<int> indentationLevels;
-    indentationLevels.push_back(0);
+    std::vector<int> indentationLevels
+    indentationLevels.push_back(0)
 
-    std::vector<int> typeDefLevels;
-    typeDefLevels.push_back(0);
+    std::vector<int> typeDefLevels
+    typeDefLevels.push_back(0)
 
     // Iterate through code lines
-    for CodeLine codeLine : m_lines
+    for int i = 0; i < m_lines.size(); i++
         // Get the code of this line
-        std::string line = codeLine.code;
+        CodeLine codeLine = m_lines[i]
+        std::string line = codeLine.code
 
         // Higher indentation level
         if codeLine.indentation > indentationLevels.back()
-            code += "{\n";
-            indentationLevels.push_back(codeLine.indentation);
+            code += "{\n"
+            indentationLevels.push_back(codeLine.indentation)
         else
             // Lower indentation level
             while codeLine.indentation < indentationLevels.back()
-                _endScope(code, indentationLevels, typeDefLevels);
+                _endScope(code, indentationLevels, typeDefLevels)
 
         // Beginning of a type definition
         if regexMatch(line, `(?:(?:private|protected|public)\s*:\s*)?(?:class|struct|enum)\s+\w+(?:\s*:(?:\s*(?:private|protected|public))?\s*(?:\w+::)*\w+(?:\s*\<.*\>)?)?`).success()
-            typeDefLevels.push_back(indentationLevels.size() + 1);
+            typeDefLevels.push_back(indentationLevels.size() + 1)
 
         // Add parentheses to conditions and loops
-        regexReplaceInPlace(line, `^((?:else\s+)?if|for|while|switch)\s+(.+?)(\s*\{\s*\})?$`, "$1($2)$3");
+        regexReplaceInPlace(line, `^((?:else\s+)?if|for|while|switch)\s+(.+?)(\s*\{\s*\})?$`, "$1($2)$3")
 
         // Add colons after switch cases
-        regexReplaceInPlace(line, "^(case .*|default)$", "$1:");
+        regexReplaceInPlace(line, "^(case .*|default)$", "$1:")
+
+        // Add semicolons
+        if (i == m_lines.size() - 1 || m_lines[i + 1].indentation <= codeLine.indentation) && (!regexMatch(line, `.*;|template\s*\<.*\>|(?:class|struct|enum)\s+.*|(?:private|protected|public):|\w+.*,|.*\}`).success())
+            line.push_back(';')
 
         // Put literal values back
         for std::pair<std::string, Literal> lit : m_literals
-            replaceAllInPlace(line, lit.first, lit.second.value());
+            replaceAllInPlace(line, lit.first, lit.second.value())
 
         // Add the origin of the line above the line
         if originMode
-            code += getOriginStr(codeLine);
+            code += getOriginStr(codeLine)
 
         // Append the line to the code and add a newline
-        code += line + '\n';
+        code += line + '\n'
 
     // Terminate all the remaining scopes
     while indentationLevels.size() > 1
-        _endScope(code, indentationLevels, typeDefLevels);
+        _endScope(code, indentationLevels, typeDefLevels)
 
-    return code;
+    return code
 
 void _addSpace(std::string &str, bool &addSpace)
     if addSpace
         // Never add spaces to the beginning of a line
         if str.size()
-            str += ' ';
+            str += ' '
 
-        addSpace = false;
+        addSpace = false
 
 std::string _rawStrToCStr(const std::string rawStr)
-    std::string escaped = regexReplace(rawStr, `("|\\)`, `\$1`);
-    escaped.back() = escaped.front() = '"';
-    return escaped;
+    std::string escaped = regexReplace(rawStr, `("|\\)`, `\$1`)
+    escaped.back() = escaped.front() = '"'
+    return escaped
 
 void Compiler::includeHeader(const std::string header, const bool warnIfAlreadyIncluded)
     if !contains(m_includes, header)
-        m_includes.push_back(header);
+        m_includes.push_back(header)
     else if warnIfAlreadyIncluded
-        printLnWarn("Header already included: " + header);
+        printLnWarn("Header already included: " + header)
 
 std::string Compiler::getCleanCode(const std::string line)
-    std::string clean;
+    std::string clean
 
-    char inLiteral = '\0';
-    int literalStart = 0;
-    std::string literal;
+    char inLiteral = '\0'
+    int literalStart = 0
+    std::string literal
 
-    bool addSpace = false;
+    bool addSpace = false
 
     for int i = 0; i < line.size(); i++
-        char c = line[i];
+        char c = line[i]
 
         // Beginning of a comment
         if !inLiteral && c == '/' && line.size() > i + 1 && line[i + 1] == '/'
-            break;
+            break
         // String or character literal
         else if (c == '"' || c == '\'' || c == '`' || c == '/') && (!isEscaped(line, i) || c == '`') && (!inLiteral || c == inLiteral)
-            _addSpace(clean, addSpace);
-            literal += c;
+            _addSpace(clean, addSpace)
+            literal += c
 
             if inLiteral
                 if inLiteral == '`' || inLiteral == '/'
-                    literal = _rawStrToCStr(literal);
+                    literal = _rawStrToCStr(literal)
 
-                std::string name = addLiteral(Literal(literal, LiteralType::String));
+                std::string name = addLiteral(Literal(literal, LiteralType::String))
 
                 if inLiteral == '/'
-                    includeHeader("regex", false);
-                    clean += "std::regex(" + name + ")";
+                    includeHeader("regex", false)
+                    clean += "std::regex(" + name + ")"
                 else
-                    clean += name;
+                    clean += name
 
-                inLiteral = '\0';
-                literal.clear();
+                inLiteral = '\0'
+                literal.clear()
             else
-                inLiteral = c;
-                literalStart = i;
+                inLiteral = c
+                literalStart = i
         // Characters inside a string or character literal
         else if inLiteral
-            literal += c;
+            literal += c
         // Whitespace outside of a string literal
         else if isWhitespace(c)
-            addSpace = true;
+            addSpace = true
         else
-            _addSpace(clean, addSpace);
-            clean += c;
+            _addSpace(clean, addSpace)
+            clean += c
 
     // Multi-line string literals are illegal
     if inLiteral
-        throw std::runtime_error("Unexpected end of line (missing string termination)");
+        throw std::runtime_error("Unexpected end of line (missing string termination)")
 
-    return clean;
+    return clean
 
 void Compiler::processLine(const std::string line, const std::string origin, const int number)
     // Include code from another file
-    RegexMatch match = regexMatch(line, `\s*#include\s+"([^"]+)";?\s*`);
+    RegexMatch match = regexMatch(line, `\s*#include\s+"([^"]+)";?\s*`)
     if match.success()
-        loadFile(getPathRelativeTo(origin, match[0]));
-        return;
+        loadFile(getPathRelativeTo(origin, match[0]))
+        return
 
     // Include C++ header
-    match = regexMatch(line, `\s*#include\s+\<?([^\<\>;]+)\>?;?\s*`);
+    match = regexMatch(line, `\s*#include\s+\<?([^\<\>;]+)\>?;?\s*`)
     if match.success()
-        includeHeader(match[0], true);
-        return;
+        includeHeader(match[0], true)
+        return
 
-    std::string clean = getCleanCode(line);
+    std::string clean = getCleanCode(line)
 
     // Skip empty lines
     if clean.size()
         // Generate a CodeLine object from the line and its metadata and store it
-        m_lines.push_back(CodeLine(origin, number, clean, getIndentation(line)));
+        m_lines.push_back(CodeLine(origin, number, clean, getIndentation(line)))

--- a/compiler/Compiler.rush
+++ b/compiler/Compiler.rush
@@ -16,7 +16,7 @@ std::string getOriginStr(const CodeLine line)
     return "// " + line.origin + " : " + std::to_string(line.number) + '\n';
 
 void Compiler::loadFile(const std::string path)
-    if (contains(m_loadedFiles, path))
+    if contains(m_loadedFiles, path)
         printLnWarn("File already loaded: " + path);
         return;
 
@@ -25,7 +25,7 @@ void Compiler::loadFile(const std::string path)
     m_loadedFiles.push_back(path);
     std::ifstream file(path);
 
-    if (!file)
+    if !file
         throw std::runtime_error("Unable to open file for reading");
 
     // Read source file lines
@@ -33,25 +33,25 @@ void Compiler::loadFile(const std::string path)
     int multiLineStart;
 
     int lineCounter = 1;
-    for (std::string line; getline(file, line); lineCounter++)
+    for std::string line; getline(file, line); lineCounter++
         // Check if the line ends with a backslash
         // Backslash means that the next line is supposed to be appended to this one
         // If there is a comment at the end of the line, remove it
         RegexMatch match = regexMatch(line, `(.*)\\\s*(?://.*)?`);
 
         // Multi-line
-        if (match.success())
+        if match.success()
             std::string beforeBackslash = match[0];
 
             // Subsequent lines
-            if (multiLineStart)
+            if multiLineStart
                 multiLine += beforeBackslash.substr(getIndentation(beforeBackslash));
             // The first line of the multi-line
             else
                 multiLine = beforeBackslash;
                 multiLineStart = lineCounter;
         // Regular single line, but the previous lines were a multi-line
-        else if (multiLineStart)
+        else if multiLineStart
             multiLine += line.substr(getIndentation(line));
             processLine(multiLine, path, multiLineStart);
 
@@ -63,14 +63,14 @@ void Compiler::loadFile(const std::string path)
 
     // Trailing multi-line at the end of a file
     // This should not really happen, but just to be safe
-    if (multiLineStart)
+    if multiLineStart
         processLine(multiLine, path, multiLineStart);
 
     printLn(`File loaded: "` + path + `"`);
 
 void _endScope(std::string &code, std::vector<int> &indentationLevels, std::vector<int> &typeDefLevels)
     // End of type definition
-    if (indentationLevels.size() == typeDefLevels.back())
+    if indentationLevels.size() == typeDefLevels.back()
         code += "};\n";
         typeDefLevels.pop_back();
     // End of a different code block
@@ -82,7 +82,7 @@ void _endScope(std::string &code, std::vector<int> &indentationLevels, std::vect
 std::string Compiler::addLiteral(const Literal value)
     std::string strType;
 
-    switch (value.type())
+    switch value.type()
         case LiteralType::String:
         strType = "STRING";
         break;
@@ -107,7 +107,7 @@ std::string Compiler::compile(const bool originMode) const
     std::string code;
 
     // Include headers
-    for (std::string include : m_includes)
+    for std::string include : m_includes
         code += "#include <" + include + ">\n";
 
     std::vector<int> indentationLevels;
@@ -117,44 +117,47 @@ std::string Compiler::compile(const bool originMode) const
     typeDefLevels.push_back(0);
 
     // Iterate through code lines
-    for (CodeLine codeLine : m_lines)
+    for CodeLine codeLine : m_lines
         // Get the code of this line
         std::string line = codeLine.code;
 
         // Higher indentation level
-        if (codeLine.indentation > indentationLevels.back())
+        if codeLine.indentation > indentationLevels.back()
             code += "{\n";
             indentationLevels.push_back(codeLine.indentation);
         else
             // Lower indentation level
-            while (codeLine.indentation < indentationLevels.back())
+            while codeLine.indentation < indentationLevels.back()
                 _endScope(code, indentationLevels, typeDefLevels);
 
         // Beginning of a type definition
-        if (regexMatch(line, `(?:(?:private|protected|public)\s*:\s*)?(?:class|struct|enum)\s+\w+(?:\s*:(?:\s*(?:private|protected|public))?\s*(?:\w+::)*\w+(?:\s*\<.*\>)?)?`).success())
+        if regexMatch(line, `(?:(?:private|protected|public)\s*:\s*)?(?:class|struct|enum)\s+\w+(?:\s*:(?:\s*(?:private|protected|public))?\s*(?:\w+::)*\w+(?:\s*\<.*\>)?)?`).success()
             typeDefLevels.push_back(indentationLevels.size() + 1);
 
+        // Add parentheses to conditions and loops
+        regexReplaceInPlace(line, `^((?:else\s+)?if|for|while|switch)\s+(.+?)(\\s*{\s*\})?$`, "$1($2)$3");
+
         // Put literal values back
-        for (std::pair<std::string, Literal> lit : m_literals)
+        for std::pair<std::string, Literal> lit : m_literals
             replaceAllInPlace(line, lit.first, lit.second.value());
 
         // Add the origin of the line above the line
-        if (originMode)
+        if originMode
             code += getOriginStr(codeLine);
 
         // Append the line to the code and add a newline
         code += line + '\n';
 
     // Terminate all the remaining scopes
-    while (indentationLevels.size() > 1)
+    while indentationLevels.size() > 1
         _endScope(code, indentationLevels, typeDefLevels);
 
     return code;
 
 void _addSpace(std::string &str, bool &addSpace)
-    if (addSpace)
+    if addSpace
         // Never add spaces to the beginning of a line
-        if (str.size())
+        if str.size()
             str += ' ';
 
         addSpace = false;
@@ -165,9 +168,9 @@ std::string _rawStrToCStr(const std::string rawStr)
     return escaped;
 
 void Compiler::includeHeader(const std::string header, const bool warnIfAlreadyIncluded)
-    if (!contains(m_includes, header))
+    if !contains(m_includes, header)
         m_includes.push_back(header);
-    else if (warnIfAlreadyIncluded)
+    else if warnIfAlreadyIncluded
         printLnWarn("Header already included: " + header);
 
 std::string Compiler::getCleanCode(const std::string line)
@@ -179,24 +182,24 @@ std::string Compiler::getCleanCode(const std::string line)
 
     bool addSpace = false;
 
-    for (int i = 0; i < line.size(); i++)
+    for int i = 0; i < line.size(); i++
         char c = line[i];
 
         // Beginning of a comment
-        if (!inLiteral && c == '/' && line.size() > i + 1 && line[i + 1] == '/')
+        if !inLiteral && c == '/' && line.size() > i + 1 && line[i + 1] == '/'
             break;
         // String or character literal
-        else if ((c == '"' || c == '\'' || c == '`' || c == '/') && (!isEscaped(line, i) || c == '`') && (!inLiteral || c == inLiteral))
+        else if (c == '"' || c == '\'' || c == '`' || c == '/') && (!isEscaped(line, i) || c == '`') && (!inLiteral || c == inLiteral)
             _addSpace(clean, addSpace);
             literal += c;
 
-            if (inLiteral)
-                if (inLiteral == '`' || inLiteral == '/')
+            if inLiteral
+                if inLiteral == '`' || inLiteral == '/'
                     literal = _rawStrToCStr(literal);
 
                 std::string name = addLiteral(Literal(literal, LiteralType::String));
 
-                if (inLiteral == '/')
+                if inLiteral == '/'
                     includeHeader("regex", false);
                     clean += "std::regex(" + name + ")";
                 else
@@ -208,17 +211,17 @@ std::string Compiler::getCleanCode(const std::string line)
                 inLiteral = c;
                 literalStart = i;
         // Characters inside a string or character literal
-        else if (inLiteral)
+        else if inLiteral
             literal += c;
         // Whitespace outside of a string literal
-        else if (isWhitespace(c))
+        else if isWhitespace(c)
             addSpace = true;
         else
             _addSpace(clean, addSpace);
             clean += c;
 
     // Multi-line string literals are illegal
-    if (inLiteral)
+    if inLiteral
         throw std::runtime_error("Unexpected end of line (missing string termination)");
 
     return clean;
@@ -226,19 +229,19 @@ std::string Compiler::getCleanCode(const std::string line)
 void Compiler::processLine(const std::string line, const std::string origin, const int number)
     // Include code from another file
     RegexMatch match = regexMatch(line, `\s*#include\s+"([^"]+)";?\s*`);
-    if (match.success())
+    if match.success()
         loadFile(getPathRelativeTo(origin, match[0]));
         return;
 
     // Include C++ header
     match = regexMatch(line, `\s*#include\s+\<?([^\<\>;]+)\>?;?\s*`);
-    if (match.success())
+    if match.success()
         includeHeader(match[0], true);
         return;
 
     std::string clean = getCleanCode(line);
 
     // Skip empty lines
-    if (clean.size())
+    if clean.size()
         // Generate a CodeLine object from the line and its metadata and store it
         m_lines.push_back(CodeLine(origin, number, clean, getIndentation(line)));

--- a/compiler/Literal.h.rush
+++ b/compiler/Literal.h.rush
@@ -2,16 +2,16 @@
 
 enum LiteralType
     Number,
-    String
+    String,
 
 class Literal
     public:
     Literal(void) {}
-    Literal(const std::string value, const LiteralType type);
+    Literal(const std::string value, const LiteralType type)
 
-    const std::string value(void) const;
-    const LiteralType type(void) const;
+    const std::string value(void) const
+    const LiteralType type(void) const
 
     private:
-    std::string m_value;
-    LiteralType m_type;
+    std::string m_value
+    LiteralType m_type

--- a/compiler/Literal.rush
+++ b/compiler/Literal.rush
@@ -3,7 +3,7 @@
 Literal::Literal(const std::string value, const LiteralType type) : m_value(value), m_type(type) {}
 
 const std::string Literal::value(void) const
-    return m_value;
+    return m_value
 
 const LiteralType Literal::type(void) const
-    return m_type;
+    return m_type

--- a/compiler/RegexMatch.h.rush
+++ b/compiler/RegexMatch.h.rush
@@ -4,29 +4,29 @@
 
 class RegexMatch
     public:
-    RegexMatch(const std::smatch m);
+    RegexMatch(const std::smatch m)
 
-    const bool success() const;
-    const int position() const;
-    const int length() const;
-    const std::string str() const;
-    const std::string prefix() const;
-    const std::string suffix() const;
+    const bool success() const
+    const int position() const
+    const int length() const
+    const std::string str() const
+    const std::string prefix() const
+    const std::string suffix() const
 
-    const bool empty() const;
-    const int size() const;
-    const std::string operator[](const int n) const;
-    const std::vector<std::string> captures() const;
-    const std::vector<std::string>::const_iterator begin() const;
-    const std::vector<std::string>::const_iterator end() const;
+    const bool empty() const
+    const int size() const
+    const std::string operator[](const int n) const
+    const std::vector<std::string> captures() const
+    const std::vector<std::string>::const_iterator begin() const
+    const std::vector<std::string>::const_iterator end() const
 
     private:
-    int m_position;
-    int m_length;
-    std::string m_str;
-    std::string m_prefix;
-    std::string m_suffix;
+    int m_position
+    int m_length
+    std::string m_str
+    std::string m_prefix
+    std::string m_suffix
 
-    bool m_empty;
-    int m_size;
-    std::vector<std::string> m_captures;
+    bool m_empty
+    int m_size
+    std::vector<std::string> m_captures

--- a/compiler/RegexMatch.rush
+++ b/compiler/RegexMatch.rush
@@ -1,48 +1,48 @@
 #include "RegexMatch.h.rush"
 
 RegexMatch::RegexMatch(const std::smatch m)
-    m_position = m.position();
-    m_length = m.length();
-    m_str = m.str();
-    m_prefix = m.prefix();
-    m_suffix = m.suffix();
+    m_position = m.position()
+    m_length = m.length()
+    m_str = m.str()
+    m_prefix = m.prefix()
+    m_suffix = m.suffix()
 
-    m_empty = m.empty();
-    m_size = m.size() - 1;
-    m_captures = std::vector<std::string>(m.begin() + 1, m.end());
+    m_empty = m.empty()
+    m_size = m.size() - 1
+    m_captures = std::vector<std::string>(m.begin() + 1, m.end())
 
 const bool RegexMatch::success() const
-    return !m_empty;
+    return !m_empty
 
 const int RegexMatch::position() const
-    return m_position;
+    return m_position
 
 const int RegexMatch::length() const
-    return m_length;
+    return m_length
 
 const std::string RegexMatch::str() const
-    return m_str;
+    return m_str
 
 const std::string RegexMatch::prefix() const
-    return m_prefix;
+    return m_prefix
 
 const std::string RegexMatch::suffix() const
-    return m_suffix;
+    return m_suffix
 
 const bool RegexMatch::empty() const
-    return m_empty;
+    return m_empty
 
 const int RegexMatch::size() const
-    return m_size;
+    return m_size
 
 const std::string RegexMatch::operator[](const int n) const
-    return m_captures[n];
+    return m_captures[n]
 
 const std::vector<std::string> RegexMatch::captures() const
-    return m_captures;
+    return m_captures
 
 const std::vector<std::string>::const_iterator RegexMatch::begin() const
-    return m_captures.begin();
+    return m_captures.begin()
 
 const std::vector<std::string>::const_iterator RegexMatch::end() const
-    return m_captures.end();
+    return m_captures.end()

--- a/compiler/main.rush
+++ b/compiler/main.rush
@@ -14,7 +14,7 @@ using namespace support;
 
 int main(const int argc, const char *const argv[])
     // Not enough arguments
-    if (argc < 2)
+    if argc < 2
         printLn("Syntax: rush <Main Rush Source File> [--keep] [--origin] [--cpp] [C++ Compiler Arguments]");
         return -1;
 
@@ -27,14 +27,14 @@ int main(const int argc, const char *const argv[])
 
     std::string cppArgs;
 
-    for (int i = 2; i < argc; i++)
+    for int i = 2; i < argc; i++
         const std::string arg = argv[i];
 
-        if (arg == "--keep")
+        if arg == "--keep"
             keepMode = true;
-        else if (arg == "--origin")
+        else if arg == "--origin"
             originMode = true;
-        else if (arg == "--cpp")
+        else if arg == "--cpp"
             cppMode = true;
         else
             cppArgs += wrapInQuotesIfContainsSpace(arg) + ' ';
@@ -49,7 +49,7 @@ int main(const int argc, const char *const argv[])
     const std::string cppCode = comp.compile(originMode);
 
     // Compiler is unable to process the Rush code
-    if (cppCode.empty())
+    if cppCode.empty()
         printLnErr("Unable to compile the Rush source code");
         return -1;
 
@@ -62,7 +62,7 @@ int main(const int argc, const char *const argv[])
     std::ofstream cppFile(cppPath);
 
     // Check if the .cpp file has been correctly opened
-    if (!cppFile.is_open())
+    if !cppFile.is_open()
         printLnErr("Unable to create a .cpp file (" + cppPath + ")");
         return -1;
 
@@ -75,22 +75,22 @@ int main(const int argc, const char *const argv[])
     ok();
 
     // Compile the C++ code using a C++ compiler
-    if (!cppMode)
+    if !cppMode
         log("Compiling the C++ code into binary");
 
         std::string cppCmd = "c++ " + cppArgs + wrapInQuotesIfContainsSpace(cppPath);
 
-        if (system(cppCmd.c_str()))
+        if system(cppCmd.c_str())
             printLnErr("Unable to compile the C++ code");
             return -1;
 
         ok();
 
         // Delete the C++ file unless in --cpp / --keep mode
-        if (!keepMode)
+        if !keepMode
             log("Deleting the C++ file");
 
-            if (remove(cppPath.c_str()))
+            if remove(cppPath.c_str())
                 printLnErr("Unable to delete the C++ file");
                 return -1;
 

--- a/compiler/main.rush
+++ b/compiler/main.rush
@@ -10,91 +10,91 @@
 #include "RegexMatch.rush"
 #include "support.rush"
 
-using namespace support;
+using namespace support
 
 int main(const int argc, const char *const argv[])
     // Not enough arguments
     if argc < 2
-        printLn("Syntax: rush <Main Rush Source File> [--keep] [--origin] [--cpp] [C++ Compiler Arguments]");
-        return -1;
+        printLn("Syntax: rush <Main Rush Source File> [--keep] [--origin] [--cpp] [C++ Compiler Arguments]")
+        return -1
 
     // Process command line arguments
-    std::string sourcePath = normalizePath(argv[1]);
+    std::string sourcePath = normalizePath(argv[1])
 
-    bool keepMode = false;
-    bool originMode = false;
-    bool cppMode = false;
+    bool keepMode = false
+    bool originMode = false
+    bool cppMode = false
 
-    std::string cppArgs;
+    std::string cppArgs
 
     for int i = 2; i < argc; i++
-        const std::string arg = argv[i];
+        const std::string arg = argv[i]
 
         if arg == "--keep"
-            keepMode = true;
+            keepMode = true
         else if arg == "--origin"
-            originMode = true;
+            originMode = true
         else if arg == "--cpp"
-            cppMode = true;
+            cppMode = true
         else
-            cppArgs += wrapInQuotesIfContainsSpace(arg) + ' ';
+            cppArgs += wrapInQuotesIfContainsSpace(arg) + ' '
 
     // Instantiate the compiler by loading the source files
-    log("Loading the Rush source code");
-    const Compiler comp(sourcePath);
-    ok();
+    log("Loading the Rush source code")
+    const Compiler comp(sourcePath)
+    ok()
 
     // Compile Rush code into C++ code
-    log("Compiling the Rush source code into C++ code");
-    const std::string cppCode = comp.compile(originMode);
+    log("Compiling the Rush source code into C++ code")
+    const std::string cppCode = comp.compile(originMode)
 
     // Compiler is unable to process the Rush code
     if cppCode.empty()
-        printLnErr("Unable to compile the Rush source code");
-        return -1;
+        printLnErr("Unable to compile the Rush source code")
+        return -1
 
-    ok();
+    ok()
 
     // Open a .cpp file and store the compiled C++ code in it
-    log("Creating .cpp file to store the C++ code");
+    log("Creating .cpp file to store the C++ code")
 
-    const std::string cppPath = sourcePath + ".cpp";
-    std::ofstream cppFile(cppPath);
+    const std::string cppPath = sourcePath + ".cpp"
+    std::ofstream cppFile(cppPath)
 
     // Check if the .cpp file has been correctly opened
     if !cppFile.is_open()
-        printLnErr("Unable to create a .cpp file (" + cppPath + ")");
-        return -1;
+        printLnErr("Unable to create a .cpp file (" + cppPath + ")")
+        return -1
 
     // Write the C++ code to the .cpp file
-    cppFile << cppCode;
+    cppFile << cppCode
 
     // Close the C++ file
-    cppFile.close();
+    cppFile.close()
 
-    ok();
+    ok()
 
     // Compile the C++ code using a C++ compiler
     if !cppMode
-        log("Compiling the C++ code into binary");
+        log("Compiling the C++ code into binary")
 
-        std::string cppCmd = "c++ " + cppArgs + wrapInQuotesIfContainsSpace(cppPath);
+        std::string cppCmd = "c++ " + cppArgs + wrapInQuotesIfContainsSpace(cppPath)
 
         if system(cppCmd.c_str())
-            printLnErr("Unable to compile the C++ code");
-            return -1;
+            printLnErr("Unable to compile the C++ code")
+            return -1
 
-        ok();
+        ok()
 
         // Delete the C++ file unless in --cpp / --keep mode
         if !keepMode
-            log("Deleting the C++ file");
+            log("Deleting the C++ file")
 
             if remove(cppPath.c_str())
-                printLnErr("Unable to delete the C++ file");
-                return -1;
+                printLnErr("Unable to delete the C++ file")
+                return -1
 
-            ok();
+            ok()
 
     // Everything worked correctly
-    return 0;
+    return 0

--- a/compiler/support.h.rush
+++ b/compiler/support.h.rush
@@ -5,60 +5,60 @@
 #include "RegexMatch.h.rush"
 
 namespace support
-    void printLn(const std::string str);
-    void printLnErr(const std::string str);
-    void printLnWarn(const std::string str);
-    void log(const std::string str);
-    void ok(void);
-    std::vector<RegexMatch> getAllMatches(const std::regex reg, const std::string str);
-    std::vector<RegexMatch> getAllMatches(const std::string reg, const std::string str);
-    RegexMatch regexMatch(const std::string str, const std::string regex);
-    RegexMatch regexSearch(const std::string str, const std::string regex);
-    std::string regexReplace(const std::string str, const std::string regex, const std::string replacement);
-    void regexReplaceInPlace(std::string &str, const std::string regex, const std::string replacement);
-    bool isWhitespace(const char c);
-    int getIndentation(const std::string str);
-    std::string readFile(const char *const path);
-    void replaceAllInPlace(std::string &str, const std::string &from, const std::string &to);
-    void replaceAllInPlace(std::string &str, const char from, const char to);
-    std::string replaceAll(const std::string &str, const std::string &from, const std::string &to);
-    std::string replaceAll(const std::string &str, const char from, const char to);
-    std::vector<std::string> split(const std::string str, const std::string delimiter);
-    std::string join(const std::string separator, const std::vector<std::string> values, const bool trailingSeparator = false);
-    bool startsWith(const std::string str, const std::string value);
-    bool isEscaped(const std::string str, const int index);
-    int findUnescaped(const std::string str, const char value, const int start = 0);
-    int indexOfFirst(const std::string str, const std::string value);
-    int indexOfFirst(const std::string str, const char value);
-    bool contains(const std::string str, const std::string value);
-    bool contains(const std::string str, const char value);
-    std::string normalizePath(const std::string path);
-    std::string getPathRelativeTo(const std::string relativeTo, const std::string path);
-    std::string wrapInQuotes(const std::string str);
-    std::string wrapInQuotesIfContainsSpace(const std::string str);
-    std::string replaceAt(const std::string str, const int start, const int length, const std::string replacement);
+    void printLn(const std::string str)
+    void printLnErr(const std::string str)
+    void printLnWarn(const std::string str)
+    void log(const std::string str)
+    void ok(void)
+    std::vector<RegexMatch> getAllMatches(const std::regex reg, const std::string str)
+    std::vector<RegexMatch> getAllMatches(const std::string reg, const std::string str)
+    RegexMatch regexMatch(const std::string str, const std::string regex)
+    RegexMatch regexSearch(const std::string str, const std::string regex)
+    std::string regexReplace(const std::string str, const std::string regex, const std::string replacement)
+    void regexReplaceInPlace(std::string &str, const std::string regex, const std::string replacement)
+    bool isWhitespace(const char c)
+    int getIndentation(const std::string str)
+    std::string readFile(const char *const path)
+    void replaceAllInPlace(std::string &str, const std::string &from, const std::string &to)
+    void replaceAllInPlace(std::string &str, const char from, const char to)
+    std::string replaceAll(const std::string &str, const std::string &from, const std::string &to)
+    std::string replaceAll(const std::string &str, const char from, const char to)
+    std::vector<std::string> split(const std::string str, const std::string delimiter)
+    std::string join(const std::string separator, const std::vector<std::string> values, const bool trailingSeparator = false)
+    bool startsWith(const std::string str, const std::string value)
+    bool isEscaped(const std::string str, const int index)
+    int findUnescaped(const std::string str, const char value, const int start = 0)
+    int indexOfFirst(const std::string str, const std::string value)
+    int indexOfFirst(const std::string str, const char value)
+    bool contains(const std::string str, const std::string value)
+    bool contains(const std::string str, const char value)
+    std::string normalizePath(const std::string path)
+    std::string getPathRelativeTo(const std::string relativeTo, const std::string path)
+    std::string wrapInQuotes(const std::string str)
+    std::string wrapInQuotesIfContainsSpace(const std::string str)
+    std::string replaceAt(const std::string str, const int start, const int length, const std::string replacement)
 
     template <class T, class U, class F>
     void map(const std::vector<T> src, std::vector<U> &dest, const F f)
-        dest.resize(src.size());
-        std::transform(src.begin(), src.end(), dest.begin(), f);
+        dest.resize(src.size())
+        std::transform(src.begin(), src.end(), dest.begin(), f)
 
     template <class T>
     std::vector<T> toVector(const T arr[], const int length)
         if length < 0
-            return nullptr;
+            return nullptr
 
-        std::vector<T> vec(arr, arr + length);
-        return vec;
+        std::vector<T> vec(arr, arr + length)
+        return vec
 
     template <class T>
     int indexOfFirst(const std::vector<T> vect, const T value)
         for int i = 0; i < vect.size(); i++
             if vect[i] == value
-                return i;
+                return i
 
-        return -1;
+        return -1
 
     template <class T>
     bool contains(const std::vector<T> vect, const T value)
-        return indexOfFirst(vect, value) >= 0;
+        return indexOfFirst(vect, value) >= 0

--- a/compiler/support.h.rush
+++ b/compiler/support.h.rush
@@ -45,7 +45,7 @@ namespace support
 
     template <class T>
     std::vector<T> toVector(const T arr[], const int length)
-        if (length < 0)
+        if length < 0
             return nullptr;
 
         std::vector<T> vec(arr, arr + length);
@@ -53,8 +53,8 @@ namespace support
 
     template <class T>
     int indexOfFirst(const std::vector<T> vect, const T value)
-        for (int i = 0; i < vect.size(); i++)
-            if (vect[i] == value)
+        for int i = 0; i < vect.size(); i++
+            if vect[i] == value
                 return i;
 
         return -1;

--- a/compiler/support.rush
+++ b/compiler/support.rush
@@ -29,7 +29,7 @@ namespace support
         std::vector<RegexMatch> matches;
 
         const std::sregex_iterator end;
-        for (std::sregex_iterator iter(str.begin(), str.end(), reg); iter != end; ++iter)
+        for std::sregex_iterator iter(str.begin(), str.end(), reg); iter != end; ++iter
             matches.push_back(RegexMatch(*iter));
 
         return matches;
@@ -59,8 +59,8 @@ namespace support
         return c == ' ' || c == '\t';
 
     int getIndentation(const std::string str)
-        for (int i = 0; i < str.size(); i++)
-            if (!isWhitespace(str[i]))
+        for int i = 0; i < str.size(); i++
+            if !isWhitespace(str[i])
                 return i;
 
         return str.size();
@@ -71,7 +71,7 @@ namespace support
         std::ifstream reader(path, std::ifstream::binary);
 
         // Check if the stream is open
-        if (!reader)
+        if !reader
             return std::string();
 
         // Go to end
@@ -95,17 +95,17 @@ namespace support
     // Source: https://stackoverflow.com/a/24315631/3043260
     void replaceAllInPlace(std::string &str, const std::string &from, const std::string &to)
         // Cannot replace an empty string
-        if (from.empty())
+        if from.empty()
             return;
 
         size_t start_pos = 0;
-        while ((start_pos = str.find(from, start_pos)) != std::string::npos)
+        while (start_pos = str.find(from, start_pos)) != std::string::npos
             str.replace(start_pos, from.length(), to);
             start_pos += to.length();
 
     void replaceAllInPlace(std::string &str, const char from, const char to)
-        for (int i = 0; i < str.size(); i++)
-            if (str[i] == from)
+        for int i = 0; i < str.size(); i++
+            if str[i] == from
                 str[i] = to;
 
     std::string replaceAll(const std::string &str, const std::string &from, const std::string &to)
@@ -116,8 +116,8 @@ namespace support
     std::string replaceAll(const std::string &str, const char from, const char to)
         std::string newStr;
 
-        for (int i = 0; i < newStr.size(); i++)
-            if (newStr[i] == from)
+        for int i = 0; i < newStr.size(); i++
+            if newStr[i] == from
                 newStr[i] = to;
 
         return newStr;
@@ -128,7 +128,7 @@ namespace support
 
         size_t start = 0;
         size_t end = str.find(delimiter);
-        while (end != std::string::npos)
+        while end != std::string::npos
             tokens.push_back(str.substr(start, end - start));
 
             start = end + delimiter.length();
@@ -143,10 +143,10 @@ namespace support
     std::string join(const std::string separator, const std::vector<std::string> values, const bool trailingSeparator)
         std::stringstream ss;
 
-        for (size_t i = 0; i < values.size(); i++)
+        for size_t i = 0; i < values.size(); i++
             ss << values[i];
 
-            if (trailingSeparator || i + 1 < values.size())
+            if trailingSeparator || i + 1 < values.size()
                 ss << separator;
 
         return ss.str();
@@ -155,8 +155,8 @@ namespace support
     bool isEscaped(const std::string str, const int index)
         bool escaped = false;
 
-        for (int i = index - 1; index >= 0; i--)
-            if (str[i] == '\\')
+        for int i = index - 1; index >= 0; i--
+            if str[i] == '\\'
                 escaped = !escaped;
             else
                 break;
@@ -167,48 +167,48 @@ namespace support
     int findUnescaped(const std::string str, const char value, const int start)
         bool escaped = false;
 
-        for (int i = start; i < str.size(); i++)
+        for int i = start; i < str.size(); i++
             char c = str[i];
 
-            if (escaped)
+            if escaped
                 escaped = false;
-            else if (c == value)
+            else if c == value
                 return i;
-            else if (c == '\\')
+            else if c == '\\'
                 escaped = true;
 
         return -1;
 
     bool startsWith(const std::string str, const std::string value)
-        if (str.size() < value.size())
+        if str.size() < value.size()
             return false;
 
-        for (int i = 0; i < value.size(); i++)
-            if (str[i] != value[i])
+        for int i = 0; i < value.size(); i++
+            if str[i] != value[i]
                 return false;
 
         return true;
 
     int indexOfFirst(const std::string str, const std::string value)
-        if (value.size() < str.size())
+        if value.size() < str.size()
             return -1;
 
-        for (int i = 0; i < str.size() - value.size() + 1; i++)
+        for int i = 0; i < str.size() - value.size() + 1; i++
             bool equals = true;
 
-            for (int j = 0; j < value.size(); j++)
-                if (str[i + j] != value[j])
+            for int j = 0; j < value.size(); j++
+                if str[i + j] != value[j]
                     equals = false;
                     break;
 
-            if (equals)
+            if equals
                 return i;
 
         return -1;
 
     int indexOfFirst(const std::string str, const char value)
-        for (int i = 0; i < str.size(); i++)
-            if (str[i] == value)
+        for int i = 0; i < str.size(); i++
+            if str[i] == value
                 return i;
 
         return -1;
@@ -236,13 +236,13 @@ namespace support
 
     std::string getPathRelativeTo(const std::string relativeTo, const std::string path)
         // Return the path if either of the paths is empty or if the path is absolute
-        if (!relativeTo.size() || !path.size() || path.front() == '/')
+        if !relativeTo.size() || !path.size() || path.front() == '/'
             return path;
 
         std::string newPath = relativeTo;
 
         // Remove the file name from the path we append to
-        while (newPath.size() && newPath.back() != '/' && newPath.back() != '\\')
+        while newPath.size() && newPath.back() != '/' && newPath.back() != '\\'
             newPath.pop_back();
 
         newPath += path;
@@ -253,7 +253,7 @@ namespace support
         return '\"' + str + '\"';
 
     std::string wrapInQuotesIfContainsSpace(const std::string str)
-        if (contains(str, ' '))
+        if contains(str, ' ')
             return wrapInQuotes(str);
         else
             return str;

--- a/compiler/support.rush
+++ b/compiler/support.rush
@@ -7,259 +7,259 @@
 namespace support
 
     // Get compilation start time
-    const std::chrono::system_clock::time_point START_TIME = std::chrono::system_clock::now();
+    const std::chrono::system_clock::time_point START_TIME = std::chrono::system_clock::now()
 
     void printLn(const std::string str)
-        std::cout << str << std::endl;
+        std::cout << str << std::endl
 
     void printLnErr(const std::string str)
-        std::cerr << "!!! ERROR: " << str << std::endl;
+        std::cerr << "!!! ERROR: " << str << std::endl
 
     void printLnWarn(const std::string str)
-        std::cerr << "*** WARNING: " << str << std::endl;
+        std::cerr << "*** WARNING: " << str << std::endl
 
     void log(const std::string str)
-        std::cout << str << " ..." << std::endl;
+        std::cout << str << " ..." << std::endl
 
     void ok(void)
-        std::chrono::duration<double> duration = std::chrono::system_clock::now() - START_TIME;
-        printLn("+++ OK (" + std::to_string(duration.count()) + " seconds)");
+        std::chrono::duration<double> duration = std::chrono::system_clock::now() - START_TIME
+        printLn("+++ OK (" + std::to_string(duration.count()) + " seconds)")
 
     std::vector<RegexMatch> getAllMatches(const std::regex reg, const std::string str)
-        std::vector<RegexMatch> matches;
+        std::vector<RegexMatch> matches
 
-        const std::sregex_iterator end;
+        const std::sregex_iterator end
         for std::sregex_iterator iter(str.begin(), str.end(), reg); iter != end; ++iter
-            matches.push_back(RegexMatch(*iter));
+            matches.push_back(RegexMatch(*iter))
 
-        return matches;
+        return matches
 
     std::vector<RegexMatch> getAllMatches(const std::string reg, const std::string str)
-        return getAllMatches(std::regex(reg), str);
+        return getAllMatches(std::regex(reg), str)
 
     RegexMatch regexMatch(const std::string str, const std::string regex)
-        std::smatch match;
-        bool success = std::regex_match(str, match, std::regex(regex));
+        std::smatch match
+        bool success = std::regex_match(str, match, std::regex(regex))
 
-        return RegexMatch(match);
+        return RegexMatch(match)
 
     RegexMatch regexSearch(const std::string str, const std::string regex)
-        std::smatch match;
-        bool success = std::regex_search(str, match, std::regex(regex));
+        std::smatch match
+        bool success = std::regex_search(str, match, std::regex(regex))
 
-        return RegexMatch(match);
+        return RegexMatch(match)
 
     std::string regexReplace(const std::string str, const std::string regex, const std::string replacement)
-        return std::regex_replace(str, std::regex(regex), replacement);
+        return std::regex_replace(str, std::regex(regex), replacement)
 
     void regexReplaceInPlace(std::string &str, const std::string regex, const std::string replacement)
-        str = regexReplace(str, regex, replacement);
+        str = regexReplace(str, regex, replacement)
 
     bool isWhitespace(const char c)
-        return c == ' ' || c == '\t';
+        return c == ' ' || c == '\t'
 
     int getIndentation(const std::string str)
         for int i = 0; i < str.size(); i++
             if !isWhitespace(str[i])
-                return i;
+                return i
 
-        return str.size();
+        return str.size()
 
     // Source: https://stackoverflow.com/a/2602258/3043260
     std::string readFile(const char *const path)
         // File must be open in binary mode for tellg() to work
-        std::ifstream reader(path, std::ifstream::binary);
+        std::ifstream reader(path, std::ifstream::binary)
 
         // Check if the stream is open
         if !reader
-            return std::string();
+            return std::string()
 
         // Go to end
-        reader.seekg(0, std::ios::end);
+        reader.seekg(0, std::ios::end)
 
         // Get the distance from the beginning of the file
-        size_t size = reader.tellg();
+        size_t size = reader.tellg()
 
         // Go to beginning
-        reader.seekg(0, std::ios::beg);
+        reader.seekg(0, std::ios::beg)
 
         // Create a string and copy the file contents into it
-        std::string buffer(size, '\0');
-        reader.read(&buffer[0], size);
+        std::string buffer(size, '\0')
+        reader.read(&buffer[0], size)
 
         // Close the stream (optional)
-        reader.close();
+        reader.close()
 
-        return buffer;
+        return buffer
 
     // Source: https://stackoverflow.com/a/24315631/3043260
     void replaceAllInPlace(std::string &str, const std::string &from, const std::string &to)
         // Cannot replace an empty string
         if from.empty()
-            return;
+            return
 
-        size_t start_pos = 0;
+        size_t start_pos = 0
         while (start_pos = str.find(from, start_pos)) != std::string::npos
-            str.replace(start_pos, from.length(), to);
-            start_pos += to.length();
+            str.replace(start_pos, from.length(), to)
+            start_pos += to.length()
 
     void replaceAllInPlace(std::string &str, const char from, const char to)
         for int i = 0; i < str.size(); i++
             if str[i] == from
-                str[i] = to;
+                str[i] = to
 
     std::string replaceAll(const std::string &str, const std::string &from, const std::string &to)
-        std::string newStr = str;
-        replaceAllInPlace(newStr, from, to);
-        return newStr;
+        std::string newStr = str
+        replaceAllInPlace(newStr, from, to)
+        return newStr
 
     std::string replaceAll(const std::string &str, const char from, const char to)
-        std::string newStr;
+        std::string newStr
 
         for int i = 0; i < newStr.size(); i++
             if newStr[i] == from
-                newStr[i] = to;
+                newStr[i] = to
 
-        return newStr;
+        return newStr
 
     // Source: https://stackoverflow.com/a/14267455/3043260
     std::vector<std::string> split(const std::string str, const std::string delimiter)
-        std::vector<std::string> tokens;
+        std::vector<std::string> tokens
 
-        size_t start = 0;
-        size_t end = str.find(delimiter);
+        size_t start = 0
+        size_t end = str.find(delimiter)
         while end != std::string::npos
-            tokens.push_back(str.substr(start, end - start));
+            tokens.push_back(str.substr(start, end - start))
 
-            start = end + delimiter.length();
-            end = str.find(delimiter, start);
+            start = end + delimiter.length()
+            end = str.find(delimiter, start)
 
-        tokens.push_back(str.substr(start, end));
+        tokens.push_back(str.substr(start, end))
 
-        return tokens;
+        return tokens
 
 
     // Source: https://stackoverflow.com/a/1430774/3043260
     std::string join(const std::string separator, const std::vector<std::string> values, const bool trailingSeparator)
-        std::stringstream ss;
+        std::stringstream ss
 
         for size_t i = 0; i < values.size(); i++
-            ss << values[i];
+            ss << values[i]
 
             if trailingSeparator || i + 1 < values.size()
-                ss << separator;
+                ss << separator
 
-        return ss.str();
+        return ss.str()
 
 
     bool isEscaped(const std::string str, const int index)
-        bool escaped = false;
+        bool escaped = false
 
         for int i = index - 1; index >= 0; i--
             if str[i] == '\\'
-                escaped = !escaped;
+                escaped = !escaped
             else
-                break;
+                break
 
-        return escaped;
+        return escaped
 
 
     int findUnescaped(const std::string str, const char value, const int start)
-        bool escaped = false;
+        bool escaped = false
 
         for int i = start; i < str.size(); i++
-            char c = str[i];
+            char c = str[i]
 
             if escaped
-                escaped = false;
+                escaped = false
             else if c == value
-                return i;
+                return i
             else if c == '\\'
-                escaped = true;
+                escaped = true
 
-        return -1;
+        return -1
 
     bool startsWith(const std::string str, const std::string value)
         if str.size() < value.size()
-            return false;
+            return false
 
         for int i = 0; i < value.size(); i++
             if str[i] != value[i]
-                return false;
+                return false
 
-        return true;
+        return true
 
     int indexOfFirst(const std::string str, const std::string value)
         if value.size() < str.size()
-            return -1;
+            return -1
 
         for int i = 0; i < str.size() - value.size() + 1; i++
-            bool equals = true;
+            bool equals = true
 
             for int j = 0; j < value.size(); j++
                 if str[i + j] != value[j]
-                    equals = false;
-                    break;
+                    equals = false
+                    break
 
             if equals
-                return i;
+                return i
 
-        return -1;
+        return -1
 
     int indexOfFirst(const std::string str, const char value)
         for int i = 0; i < str.size(); i++
             if str[i] == value
-                return i;
+                return i
 
-        return -1;
+        return -1
 
     bool contains(const std::string str, const std::string value)
-        return indexOfFirst(str, value) >= 0;
+        return indexOfFirst(str, value) >= 0
 
     bool contains(const std::string str, const char value)
-        return indexOfFirst(str, value) >= 0;
+        return indexOfFirst(str, value) >= 0
 
     std::string normalizePath(const std::string path)
-        std::string newPath = path;
+        std::string newPath = path
 
         // Convert Windows path separators to UNIX ones
-        replaceAllInPlace(newPath, '\\', '/');
+        replaceAllInPlace(newPath, '\\', '/')
 
         // Remove duplicit slashes
-        regexReplaceInPlace(newPath, "/{2,}", "/");
+        regexReplaceInPlace(newPath, "/{2,}", "/")
         // Remove "this directory" pointers
-        regexReplaceInPlace(newPath, `(^|/)\./`, "$1");
+        regexReplaceInPlace(newPath, `(^|/)\./`, "$1")
         // Remove unnecessary "parent directory" pointers
-        regexReplaceInPlace(newPath, `[^/]+/\.\./`, "");
+        regexReplaceInPlace(newPath, `[^/]+/\.\./`, "")
 
-        return newPath;
+        return newPath
 
     std::string getPathRelativeTo(const std::string relativeTo, const std::string path)
         // Return the path if either of the paths is empty or if the path is absolute
         if !relativeTo.size() || !path.size() || path.front() == '/'
-            return path;
+            return path
 
-        std::string newPath = relativeTo;
+        std::string newPath = relativeTo
 
         // Remove the file name from the path we append to
         while newPath.size() && newPath.back() != '/' && newPath.back() != '\\'
-            newPath.pop_back();
+            newPath.pop_back()
 
-        newPath += path;
+        newPath += path
 
-        return normalizePath(newPath);
+        return normalizePath(newPath)
 
     std::string wrapInQuotes(const std::string str)
-        return '\"' + str + '\"';
+        return '\"' + str + '\"'
 
     std::string wrapInQuotesIfContainsSpace(const std::string str)
         if contains(str, ' ')
-            return wrapInQuotes(str);
+            return wrapInQuotes(str)
         else
-            return str;
+            return str
 
     std::string replaceAt(const std::string str, const int start, const int length, const std::string replacement)
-        std::string prefix = str.substr(0, start);
-        std::string suffix = str.substr(start + length);
+        std::string prefix = str.substr(0, start)
+        std::string suffix = str.substr(start + length)
 
-        return prefix + replacement + suffix;
+        return prefix + replacement + suffix

--- a/examples/HelloWorld.rush
+++ b/examples/HelloWorld.rush
@@ -1,5 +1,5 @@
 #include iostream
 
 int main(void)
-    std::cout << "Hello World!" << std::endl;
-    return 0;
+    std::cout << "Hello World!" << std::endl
+    return 0

--- a/examples/LibTest.rush
+++ b/examples/LibTest.rush
@@ -1,9 +1,9 @@
-#include "../library/rushlib.h.rush"
+#include "../library/rushlib.rush"
 #include <iostream>
 
 int main(void)
-    rush::String str = "Hello World!";
-    std::cout << str << std::endl;
-    std::cout << str.StartsWith("Hello") << std::endl;
-    std::cout << str.EndsWith("World!") << std::endl;
-    return 0;
+    rush::String str = "Hello World!"
+    std::cout << str << std::endl
+    std::cout << str.StartsWith("Hello") << std::endl
+    std::cout << str.EndsWith("World!") << std::endl
+    return 0

--- a/library/Regex.rush
+++ b/library/Regex.rush
@@ -1,22 +1,22 @@
 namespace rush
     RegexMatch Regex::Match(const String str) const
         RegexMatch match
-        std::regex_match(str, match, this)
+        std::regex_match(str, match, *this)
         return match
 
     RegexMatch Regex::Search(const String str) const
         RegexMatch match
-        std::regex_search(str, match, this)
+        std::regex_search(str, match, *this)
         return match
 
     String Regex::Replace(const String str, const String replacement) const
-        return std::regex_replace(str, this, replacement)
+        return std::regex_replace(str, *this, replacement)
 
     List<RegexMatch> Regex::FindAllMatches(const String str) const
         List<RegexMatch> matches;
 
         const std::sregex_iterator end;
-        for std::sregex_iterator iter(str.begin(), str.end(), reg); iter != end; ++iter
-            matches.push_back(Match(*iter))
+        for std::sregex_iterator iter(str.begin(), str.end(), *this); iter != end; ++iter
+            matches.push_back(RegexMatch(*iter))
 
         return matches;

--- a/library/Regex.rush
+++ b/library/Regex.rush
@@ -1,22 +1,22 @@
 namespace rush
     RegexMatch Regex::Match(const String str) const
-        RegexMatch match;
-        std::regex_match(str, match, this);
-        return match;
+        RegexMatch match
+        std::regex_match(str, match, this)
+        return match
 
     RegexMatch Regex::Search(const String str) const
-        RegexMatch match;
-        std::regex_search(str, match, this);
-        return match;
+        RegexMatch match
+        std::regex_search(str, match, this)
+        return match
 
     String Regex::Replace(const String str, const String replacement) const
-        return std::regex_replace(str, this, replacement);
+        return std::regex_replace(str, this, replacement)
 
     List<RegexMatch> Regex::FindAllMatches(const String str) const
         List<RegexMatch> matches;
 
         const std::sregex_iterator end;
-        for (std::sregex_iterator iter(str.begin(), str.end(), reg); iter != end; ++iter)
-            matches.push_back(Match(*iter));
+        for std::sregex_iterator iter(str.begin(), str.end(), reg); iter != end; ++iter
+            matches.push_back(Match(*iter))
 
         return matches;

--- a/library/String.rush
+++ b/library/String.rush
@@ -1,27 +1,27 @@
 namespace rush
     bool String::StartsWith(const String str) const
-        const int strSize = str.size();
+        const int strSize = str.size()
 
-        if (strSize > size())
-            return false;
+        if strSize > size()
+            return false
 
-        for (int i = 0; i < strSize; i++)
-            if (str[i] != at(i))
-                return false;
+        for int i = 0; i < strSize; i++
+            if str[i] != at(i)
+                return false
 
         return true;
 
     bool String::EndsWith(const String str) const
-        const int strSize = str.size();
-        const int thisSize = size();
+        const int strSize = str.size()
+        const int thisSize = size()
 
-        if (strSize > thisSize)
-            return false;
+        if strSize > thisSize
+            return false
 
-        const int offset = thisSize - strSize;
+        const int offset = thisSize - strSize
 
-        for (int i = 0; i < strSize; i++)
-            if (str[i] != at(offset + i))
-                return false;
+        for int i = 0; i < strSize; i++
+            if str[i] != at(offset + i)
+                return false
 
-        return true;
+        return true

--- a/library/rushlib.h.rush
+++ b/library/rushlib.h.rush
@@ -6,8 +6,8 @@ namespace rush
     class String : public std::string
         public: String(const char *const str) : std::string(str) {}
         public: String(const std::string str) : std::string(str) {}
-        public: bool StartsWith(const String str) const;
-        public: bool EndsWith(const String str) const;
+        public: bool StartsWith(const String str) const
+        public: bool EndsWith(const String str) const
 
     template <class T>
     class List : public std::vector<T>
@@ -20,7 +20,7 @@ namespace rush
         public: Regex(const char *const pattern) : std::regex(pattern) {}
         public: Regex(const std::string pattern) : std::regex(pattern) {}
         public: Regex(const std::regex regex) : std::regex(regex) {}
-        public: RegexMatch Match(const String str) const;
-        public: RegexMatch Search(const String str) const;
-        public: String Replace(const String str, const String replacement) const;
-        public: List<RegexMatch> FindAllMatches(const String str) const;
+        public: RegexMatch Match(const String str) const
+        public: RegexMatch Search(const String str) const
+        public: String Replace(const String str, const String replacement) const
+        public: List<RegexMatch> FindAllMatches(const String str) const

--- a/library/rushlib.h.rush
+++ b/library/rushlib.h.rush
@@ -4,6 +4,7 @@
 
 namespace rush
     class String : public std::string
+        public: String(void) : std::string() {}
         public: String(const char *const str) : std::string(str) {}
         public: String(const std::string str) : std::string(str) {}
         public: bool StartsWith(const String str) const
@@ -11,12 +12,15 @@ namespace rush
 
     template <class T>
     class List : public std::vector<T>
+        public: List<T>(void) : std::vector<T>() {}
         public: List<T>(const std::vector<T> vector) : std::vector<T>(vector) {}
 
     class RegexMatch : public std::smatch
+        public: RegexMatch(void) : std::smatch() {}
         public: RegexMatch(const std::smatch match) : std::smatch(match) {}
 
     class Regex : public std::regex
+        public: Regex(void) : std::regex() {}
         public: Regex(const char *const pattern) : std::regex(pattern) {}
         public: Regex(const std::string pattern) : std::regex(pattern) {}
         public: Regex(const std::regex regex) : std::regex(regex) {}


### PR DESCRIPTION
- Conditions are no longer written in parentheses (`if`, `while`, `for`)
- The expression evaluated by `switch` is no longer written in parentheses
- `switch` `case`s are no longer followed by a colon, including `default`